### PR TITLE
Update my references

### DIFF
--- a/citations.bib
+++ b/citations.bib
@@ -156,7 +156,7 @@
 
 @misc{Zelle2018rmzelle/ref-extractor,
 	title = {rmzelle/ref-extractor},
-	url = {https://github.com/rmzelle/ref-extractor},
+	howpublished={\url{https://github.com/rmzelle/ref-extractor}},
 	author = {Zelle, Rintze M. and Zumstein, Philipp},
 	date = {2018-11-23},
 	year = {2018},
@@ -417,7 +417,7 @@
 
 @misc{zelle_csl_2012,
 	title = {{CSL} 1.0.1 {Specification}},
-	howpublished = {\url{http://docs.citationstyles.org/en/1.0.1/specification.html}},
+	howpublished = {\url{https://docs.citationstyles.org/en/1.0.1/specification.html}},
 	urldate = {2018-12-30},
 	author = {Zelle, Rintze M},
 	month = sep,


### PR DESCRIPTION
https://github.com/rmzelle/ref-extractor citation was missing an URL, and the CSL specification is available through HTTPS. Currently rendered as:

![image](https://user-images.githubusercontent.com/77951/61192981-38c87300-a686-11e9-8710-09ca8c0b1eb2.png)

v2 (11 July, 2019), https://peerj.com/preprints/27466v2/